### PR TITLE
Pegnott/issue166 Show active user count & list 

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { Modal } from "./modal/Modal"
 import { get_store } from "./state/store"
 import { check_and_handle_connection_and_session } from "./sync/user_info/window_focus_session_check"
 import { date_to_string } from "./form/datetime_utils"
+import { ActiveUserWidget } from "./sharedf/ActiveUserWidget"
 
 
 
@@ -81,6 +82,7 @@ function App(props: Props)
                             <Box className={`${classes.toolbar_item}`}><ActiveCreatedAtFilterWarning /></Box>
                             <Box className={`${classes.toolbar_item}`}><ActiveCreationContextWarning /></Box>
                             <Box className={`${classes.toolbar_item}`}><ActiveFilterWarning /></Box>
+                            <Box className={`${classes.toolbar_item}`}><ActiveUserWidget /></Box>
                             <Box className={`${classes.toolbar_item}`}><SyncInfo /></Box>
                             <Box className={`${classes.toolbar_item}`}><StorageInfo /></Box>
                             <Box className={`${classes.toolbar_item}`}><UserInfo /></Box>

--- a/app/frontend/src/sharedf/ActiveUserWidget.tsx
+++ b/app/frontend/src/sharedf/ActiveUserWidget.tsx
@@ -8,7 +8,7 @@ import { useState } from "react"
 
 export function ActiveUserWidget ()
 {
-    const active_user_count = 10 + 0
+    const active_user_count = 0 + 0
     const classes = use_styles()
     const [user_list_is_open, set_user_list_is_open] = useState(false)
 

--- a/app/frontend/src/sharedf/ActiveUserWidget.tsx
+++ b/app/frontend/src/sharedf/ActiveUserWidget.tsx
@@ -1,0 +1,96 @@
+import { h } from "preact"
+import { Avatar, Badge, Box, Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, List, ListItem, ListItemAvatar, ListItemText, makeStyles, withStyles } from "@material-ui/core"
+import PersonIcon from "@material-ui/icons/Person"
+import PeopleIcon from "@material-ui/icons/People"
+import { useState } from "react"
+
+
+
+export function ActiveUserWidget ()
+{
+    const active_user_count = 10 + 0
+    const classes = use_styles()
+    const [user_list_is_open, set_user_list_is_open] = useState(false)
+
+    const handleClickOpen = () => {
+        set_user_list_is_open(true)
+    }
+
+    const handleClose = (value: string) => {
+        set_user_list_is_open(false)
+    }
+
+    if (active_user_count <= 0) return null
+
+
+    return (
+        <Box>
+            <IconButton
+                aria-label={`${active_user_count}  Active users`}
+                className={classes.button}
+                onClick={handleClickOpen}
+                size="small"
+            >
+                <StyledBadge
+                    badgeContent={active_user_count}
+                    color="secondary"
+                    overlap="rectangle"
+                    max={10}
+                >
+                    {(active_user_count == 1) && <PersonIcon className={classes.icon} />}
+                    {(active_user_count > 1) && <PeopleIcon className={classes.icon} />}
+
+                </StyledBadge>
+            </IconButton>
+            <Dialog open={user_list_is_open} onClose={handleClose} scroll="paper">
+                <DialogTitle>Active Users</DialogTitle>
+                <DialogContent>
+                    <List dense>
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <PersonIcon />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary="username1" secondary="user1@email.com" />
+                        </ListItem>
+
+                        <ListItem>
+                            <ListItemAvatar>
+                                <Avatar>
+                                    <PersonIcon />
+                                </Avatar>
+                            </ListItemAvatar>
+                            <ListItemText primary="username2" secondary="user2@email.com" />
+                        </ListItem>
+                    </List>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>
+                        Close
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Box>
+    )
+}
+
+
+const StyledBadge = withStyles((theme) => ({
+    badge: {
+        top:2, right:"-0.42em",
+        zIndex: 1,
+    },
+  }))(Badge)
+
+const use_styles = makeStyles(theme => ({
+    button: {
+        display:"inline-block",
+        marginRight:"1em",
+        border: `1px ${theme.palette.divider} solid`
+    },
+    icon: {
+        position:"relative",
+        zIndex:10,
+    }
+}))

--- a/app/frontend/src/wcomponent_canvas/node/NodeSubStateSummary.tsx
+++ b/app/frontend/src/wcomponent_canvas/node/NodeSubStateSummary.tsx
@@ -69,6 +69,8 @@ function _NodeSubStateSummary (props: Props)
                 sim_ms={props.sim_ms}
             />
         }
+        // type guard
+        else if (target_value_id_type === undefined || target_value === undefined) return null
         else
         {
             let value_text = target_value


### PR DESCRIPTION
Adds a user count widget component, inserts in the app header area, and allows clicking to open a list of active users (currently the count and user info is hard coded placeholder info)